### PR TITLE
[myMovie] 선택된 년도 별 카드 필터링

### DIFF
--- a/src/components/MovieHeader.tsx
+++ b/src/components/MovieHeader.tsx
@@ -10,6 +10,7 @@ export interface MyMovieProps {
 
 function MovieHeader(props: MyMovieProps) {
   const { data, setFetchURL } = props;
+  const wathedMovieYear = ['전체', '2023', '2022'];
   const watchedMoviesNum = data?.data?.pageInfoRes?.totalElements;
   const [selectedOption, setSelectedOption] = useState('');
 
@@ -50,9 +51,9 @@ function MovieHeader(props: MyMovieProps) {
 
       <StHeaderBtnWrapper>
         <StYearSelector onChange={handleSelectedOption}>
-          <StYearOption>전체</StYearOption>
-          <StYearOption>2023</StYearOption>
-          <StYearOption>2022</StYearOption>
+          {wathedMovieYear.map((year) => {
+            return <StYearOption>{year}</StYearOption>;
+          })}
         </StYearSelector>
         <IcGoButton style={{ width: '4.9rem' }} />
         <ICAddAudience style={{ width: '11.7rem' }} />

--- a/src/components/MovieHeader.tsx
+++ b/src/components/MovieHeader.tsx
@@ -1,14 +1,45 @@
 import { styled } from 'styled-components';
-import { IcAllDropdown, IcGoButton, ICAddAudience } from '../asset/icon';
+import { IcGoButton, ICAddAudience } from '../asset/icon';
 import { MovieDataInfo } from '../types/MovieData';
+import { useEffect, useState } from 'react';
 
 export interface MyMovieProps {
   data: MovieDataInfo;
+  setFetchURL: React.Dispatch<React.SetStateAction<string>>;
 }
 
 function MovieHeader(props: MyMovieProps) {
-  const { data } = props;
+  const { data, setFetchURL } = props;
   const watchedMoviesNum = data?.data?.pageInfoRes?.totalElements;
+  const [selectedOption, setSelectedOption] = useState('');
+
+  useEffect(() => {
+    handleFetchURL();
+  }, [selectedOption]);
+
+  const handleFetchURL = () => {
+    switch (selectedOption) {
+      case '전체':
+        setFetchURL('/user/1/movielog/watched?page=1&size=6');
+        break;
+
+      case '2023':
+        setFetchURL('/user/1/movielog/watched?page=1&size=6&year=2023');
+        break;
+
+      case '2022':
+        setFetchURL('/user/1/movielog/watched?page=1&size=6&year=2022');
+        break;
+
+      default:
+        setFetchURL('/user/1/movielog/watched?page=1&size=6');
+        break;
+    }
+  };
+
+  const handleSelectedOption = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedOption(e.target.value);
+  };
 
   return (
     <StMyMovieHeader>
@@ -18,7 +49,11 @@ function MovieHeader(props: MyMovieProps) {
       </StHeaderTextWrapper>
 
       <StHeaderBtnWrapper>
-        <IcAllDropdown style={{ width: '7rem' }} />
+        <StYearSelector onChange={handleSelectedOption}>
+          <StYearOption>전체</StYearOption>
+          <StYearOption>2023</StYearOption>
+          <StYearOption>2022</StYearOption>
+        </StYearSelector>
         <IcGoButton style={{ width: '4.9rem' }} />
         <ICAddAudience style={{ width: '11.7rem' }} />
       </StHeaderBtnWrapper>
@@ -30,6 +65,7 @@ const StMyMovieHeader = styled.header`
   display: flex;
   justify-content: space-between;
   width: 89.3rem;
+  height: 3.7rem;
 `;
 
 const StHeaderTextWrapper = styled.span`
@@ -56,6 +92,16 @@ const StHeaderBtnWrapper = styled.span`
   > svg {
     height: 3.7rem;
   }
+`;
+
+const StYearSelector = styled.select`
+  width: 7rem;
+  height: 3.7rem;
+  border: 1px solid #e3e3e3;
+`;
+
+const StYearOption = styled.option`
+  ${({ theme }) => theme.colors.gray70}
 `;
 
 export default MovieHeader;

--- a/src/components/MovieHeader.tsx
+++ b/src/components/MovieHeader.tsx
@@ -51,8 +51,8 @@ function MovieHeader(props: MyMovieProps) {
 
       <StHeaderBtnWrapper>
         <StYearSelector onChange={handleSelectedOption}>
-          {wathedMovieYear.map((year) => {
-            return <StYearOption>{year}</StYearOption>;
+          {wathedMovieYear.map((year, idx) => {
+            return <StYearOption key={idx}>{year}</StYearOption>;
           })}
         </StYearSelector>
         <IcGoButton style={{ width: '4.9rem' }} />

--- a/src/components/MyMovie.tsx
+++ b/src/components/MyMovie.tsx
@@ -13,7 +13,7 @@ function MyMovie() {
 
   return (
     <StTopWrapper>
-      <UserPreference data_1={data} />
+      <UserPreference numData={data} />
       <StMyMovieSection>
         <MovieHeader data={data} setFetchURL={setFetchURL} />
 

--- a/src/components/MyMovie.tsx
+++ b/src/components/MyMovie.tsx
@@ -4,16 +4,18 @@ import MovieCard from './MovieCard';
 import UserPreference from './UserPreference';
 import client from '../libs/axios';
 import useSWR from 'swr';
+import { useState } from 'react';
 
 function MyMovie() {
   const fetcher = (url: string) => client.get(url).then((res) => res.data);
-  const { data } = useSWR('/user/1/movielog/watched?page=1&size=6&year=2023', fetcher);
+  const [fetchURL, setFetchURL] = useState('/user/1/movielog/watched?page=1&size=6');
+  const { data } = useSWR(fetchURL, fetcher);
 
   return (
     <StTopWrapper>
       <UserPreference data_1={data} />
       <StMyMovieSection>
-        <MovieHeader data={data} />
+        <MovieHeader data={data} setFetchURL={setFetchURL} />
 
         <StMovieCardWrapper>
           {data?.data.page.map((data: object, idx: number) => {

--- a/src/components/PreferenceNav.tsx
+++ b/src/components/PreferenceNav.tsx
@@ -15,7 +15,7 @@ function PreferenceNav(props: PreferenceNavProps) {
   const watchedMoviesNum = numData?.data?.pageInfoRes?.totalElements;
 
   return (
-    <StInfoWrapper className={data.class}>
+    <StInfoWrapper id={data.class}>
       <StNumInfo>{idx === 1 ? watchedMoviesNum : 0}</StNumInfo>
       {data.content && <StPointerIcon>{data.content}</StPointerIcon>}
       <StTextInfo>{data.text}</StTextInfo>
@@ -33,7 +33,7 @@ const StInfoWrapper = styled.div`
   border: 0.1rem solid ${({ theme }) => theme.colors.gray40};
   border-radius: 0.5rem;
 
-  &.selected {
+  &#selected {
     background-color: ${({ theme }) => theme.colors.red2};
     color: ${({ theme }) => theme.colors.white};
   }

--- a/src/components/UserPreference.tsx
+++ b/src/components/UserPreference.tsx
@@ -8,13 +8,13 @@ import useSWR from 'swr';
 import { NavDataInfo } from '../types/MovieData';
 
 export interface UserPreferenceProps {
-  data_1: NavDataInfo;
+  numData: NavDataInfo;
 }
 
 const UserPreference = (props: UserPreferenceProps) => {
   const fetcher = (url: string) => client.get(url).then((res) => res.data);
   const { data } = useSWR('/user/1', fetcher);
-  const { data_1 } = props;
+  const { numData } = props;
 
   return (
     <StUserInfo>
@@ -26,7 +26,7 @@ const UserPreference = (props: UserPreferenceProps) => {
       </StUserProfile>
 
       {NAV_DATA.map((data, idx) => {
-        return <PreferenceNav data={data} key={idx} numData={data_1} idx={idx} />;
+        return <PreferenceNav data={data} key={idx} numData={numData} idx={idx} />;
       })}
     </StUserInfo>
   );


### PR DESCRIPTION
## 🔥 Related Issues

resolved #23

## 💜 작업 내용

- [x]  년도 선택 이미지 → 드롭다운 select로 변경
- [x]  년도가 선택될 때마다 data 불러오는 주소가 달라짐 (year 추가)
- [x]  선택된 년도에 맞는 영화 카드가 나올 수 있도록 구현

<br />

## ✅ PR Point

- 기본 url은 년도 정보가 포함되지 않은 주소로 지정해서, 시청한 모든 영화 정보를 가져오도록 했어요!

```tsx
// MyMovie.tsx
const fetcher = (url: string) => client.get(url).then((res) => res.data);
const [fetchURL, setFetchURL] = useState('/user/1/movielog/watched?page=1&size=6');
const { data } = useSWR(fetchURL, fetcher);
```

- 년도 정보가 바뀔 때마다, url도 변경되도록 props로 setFetchURL을 내려줬어요.

```tsx
// MyMovie.tsx
return <MovieHeader data={data} setFetchURL={setFetchURL} />
```

- 선택된 년도가 바뀔 때마다 데이터 패칭 url을 변경해줬어요!

```tsx
// MovieHeader.tsx
useEffect(() => {
    handleFetchURL();
  }, [selectedOption]);

const handleFetchURL = () => {
  switch (selectedOption) {
    case '전체':
      setFetchURL('/user/1/movielog/watched?page=1&size=6');
      break;

    case '2023':
      setFetchURL('/user/1/movielog/watched?page=1&size=6&year=2023');
      break;

    case '2022':
      setFetchURL('/user/1/movielog/watched?page=1&size=6&year=2022');
      break;

    default:
      setFetchURL('/user/1/movielog/watched?page=1&size=6');
      break;
    }
  };
```

<br />

## 😡 Trouble Shooting

- 년도 선택 옵션을 가져온 데이터를 활용해서 하고 싶었는데, 이 부분이 생각보다 잘 해결되지 않았어요.
- 년도 정보를 가져오면 [’2023’, ‘2023’, ‘2023’, ‘2022’] 이런 식으로 `중복된 정보들` 이 있는데 이걸 어떤 식으로 `필터링`해서 사용할 수 있을지..
- 계속 고민하고 있는데, 지금은 배열로 넣어 놨지만 추후에 수정할 예정입니다! 많은 의견 부탁드려용!!

```tsx
// MovieHeader.tsx
const wathedMovieYear = ['전체', '2023', '2022'];

<StYearSelector onChange={handleSelectedOption}>
  {wathedMovieYear.map((year) => {
    return <StYearOption>{year}</StYearOption>;
  })}
</StYearSelector>
```

<br />

## ☀️ 스크린샷 / GIF / 화면 녹화
![image](https://github.com/SOPT-CDS-WEB-6/CDS-Client/assets/80264647/bf1616ce-dd11-4695-82e3-a90c0b8e6ba5)

---

![image](https://github.com/SOPT-CDS-WEB-6/CDS-Client/assets/80264647/21210fcc-d559-43ac-a85a-a8077c4b6c4a)

---

![image](https://github.com/SOPT-CDS-WEB-6/CDS-Client/assets/80264647/6f280fa6-2840-4895-a8ee-63f2daf09103)
