### PR TITLE
[Header] header 컴포넌트 스타일 수정

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -116,6 +116,7 @@ const StHeaderNavOverMenuDataText = styled.span`
 
 const StHeaderNavOverMenuTitleText = styled.h2`
   ${({ theme }) => theme.fonts.Body3};
+  font-weight: 700;
 `;
 
 const StheaderSplitLine = styled.div`
@@ -145,20 +146,25 @@ const StHeaderNavOverMenu = styled.dl`
 
 const StHeaderNavMenu = styled.li`
   display: flex;
-  align-items: center;
 
   width: 20.3rem;
   height: 100%;
+  padding-top: 2.1rem;
 `;
 
 const StHeaderNavDetailBar = styled.ul`
   position: absolute;
   display: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   left: 0;
   top: 18rem;
 
   width: 100%;
   height: 43.4rem;
+
+  background-color: ${({ theme }) => theme.colors.white};
 
   &.hover {
     display: flex;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -155,9 +155,6 @@ const StHeaderNavMenu = styled.li`
 const StHeaderNavDetailBar = styled.ul`
   position: absolute;
   display: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   left: 0;
   top: 18rem;
 

--- a/src/components/common/StickyHeader.tsx
+++ b/src/components/common/StickyHeader.tsx
@@ -94,12 +94,8 @@ const StStickyHeaderWrapper = styled.section`
 
 const StStickyHeader = styled.header`
   display: none;
-  /* display: flex;
-  justify-content: center;
-  align-items: center; */
   position: fixed;
   top: 0;
-
   width: 100%;
   height: 7.6rem;
 
@@ -109,6 +105,7 @@ const StStickyHeader = styled.header`
     display: flex;
     justify-content: center;
     align-items: center;
+    z-index: 4;
   }
 
   & > svg {

--- a/src/components/home/MovieChartCard.tsx
+++ b/src/components/home/MovieChartCard.tsx
@@ -78,7 +78,7 @@ const StMovieButtonWrapper = styled.div`
   position: absolute;
   top: 13rem;
   left: 7rem;
-  z-index: 99;
+  z-index: 3;
 
   cursor: pointer;
 


### PR DESCRIPTION
## 🔥 Related Issues
resolved #33 
header인데 브랜치 네이밍 이슈^^

## 💜 작업 내용
- [x] header 컴포넌트의 overMenu background color 추가
- [x] sticky header z-index 추가 

## ✅ PR Point
```tsx
// src/components/common/StickyHeader.tsx
const StStickyHeader = styled.header`
  display: none;
  position: fixed;
  top: 0;
  width: 100%;
  height: 7.6rem;

  background: ${({ theme }) => theme.colors.cgv_gradient};

  &.sticky {
    display: flex;
    justify-content: center;
    align-items: center;
    z-index: 4;
  }

  & > svg {
    margin-right: 5.5rem;

    cursor: pointer;
  }
`;
```
```tsx
// src/components/home/MovieChartCard.tsx
const StShadowCard = styled.div`
  content: '';
  display: flex;
  align-items: flex-end;
  position: absolute;
  z-index: 2;
  left: 0;
  top: 0;

  width: 100%;
  height: 100%;
  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.09) 35%, rgba(0, 0, 0, 0.85));
`;

const StMovieButtonWrapper = styled.div`
  display: none;
  flex-direction: column;

  position: absolute;
  top: 13rem;
  left: 7rem;
  z-index: 3;

  cursor: pointer;

  &.hover {
    display: flex;
  }
`;
```
StickyHeader의 컴포넌트가 가장 위로 와야하기에 z-index를 가장 크게 갖고 갔습니다. 영화 포스터의 경우 그 위에 올라오는 absolute position을 갖는 tag들이 있어서 z-index를 StickyHeader보다 작게 수정했습니다.

## 😡 Trouble Shooting
- 어떤 어려움이 있었고 어떻게 해결했는지

## ☀️ 스크린샷 / GIF / 화면 녹화 

